### PR TITLE
fix fidl imports

### DIFF
--- a/pyfranca/franca_processor.py
+++ b/pyfranca/franca_processor.py
@@ -27,7 +27,7 @@ class Processor:
         Constructor.
         """
         # Default package paths.
-        self.package_paths = ["."]
+        self.package_paths = []
         self.files = {}
         self.packages = {}
 
@@ -393,6 +393,9 @@ class Processor:
         # Parse the file.
         parser = franca_parser.Parser()
         package = parser.parse_file(fspec)
+        fspec_path = os.path.abspath(fspec)
+        fspec_dir = os.path.split(fspec_path)
+        self.package_paths.extend(fspec_dir)
         # Import the package in the processor.
         self.import_package(fspec, package, references)
         return package


### PR DESCRIPTION
Hi Kaloyan,

I test your latest pyfranca version but run into some errors. If I check my files with the validator, it told me that it not find definition.fild. Both fidl files are located in the same directory.
```
"C:\Program Files (x86)\Python36-32\python.exe" E:/project/pyfranca/pyfranca/tools/fidl_validator.py E:\project\pyfranca\tsd.helloworld.api\idl\Hello.fidl
ERROR: Model 'definitions.fidl' not found.

Process finished with exit code 1

```

I take a look into your changes and found out that your default path for looking for fidl file is "." the current working directory. Your current solution will only work if you run the validator within the fidl direktory. Ich changed this behavior a little bit. I add the directories of the commandline fidl files. Now the validator is working independent of the current work directory. I hope you find this change usefull. 

jens