### PR TITLE
add unittest to check invalid behavior, fix import

### DIFF
--- a/pyfranca/franca_processor.py
+++ b/pyfranca/franca_processor.py
@@ -385,11 +385,11 @@ class Processor:
                     "Model '{}' not found.".format(fspec))
             else:
                 # Relative specification.
-                package_paths = self.package_paths
+                package_paths = self.package_paths[:]
                 if package_path:
                     package_paths.insert(0, package_path)
                 # Check in the package path list.
-                for path in self.package_paths:
+                for path in package_paths:
                     temp_fspec = os.path.join(path, fspec)
                     if os.path.exists(temp_fspec):
                         fspec = temp_fspec

--- a/pyfranca/tests/fidl/idl/P.fidl
+++ b/pyfranca/tests/fidl/idl/P.fidl
@@ -1,0 +1,19 @@
+package P
+
+import P.T.* from "definitions.fidl"
+
+
+interface I {
+	version { major 1 minor 0 }
+
+	method sendData
+	{
+		out {
+              Int32 outVal
+           }
+
+		in {
+              MyStruct inVal
+           }
+	}
+}

--- a/pyfranca/tests/fidl/idl/definitions.fidl
+++ b/pyfranca/tests/fidl/idl/definitions.fidl
@@ -1,0 +1,18 @@
+package P
+
+typeCollection T {
+    version { major 1 minor 0 }
+
+	enumeration MyEnum {
+		abc
+		def
+		ghi
+		jkm
+	}
+
+	struct MyStruct {
+		UInt8 val1
+		MyEnum val2
+		String  msg
+	}
+}

--- a/pyfranca/tests/fidl/idl2/P2.fidl
+++ b/pyfranca/tests/fidl/idl2/P2.fidl
@@ -1,0 +1,19 @@
+package P2
+
+import P.T.* from "definitions.fidl"
+
+
+interface I2 {
+	version { major 1 minor 0 }
+
+	method getData
+	{
+		out {
+              MyStruct outVal
+           }
+
+		in {
+              Int32 inVal
+           }
+	}
+}

--- a/pyfranca/tests/test_franca_processor.py
+++ b/pyfranca/tests/test_franca_processor.py
@@ -550,3 +550,10 @@ class TestReferences(BaseTestCase):
         self.assertEqual(m.out_args["tda"].type.type.reference, td)
         b = i.broadcasts["B"]
         self.assertEqual(b.out_args["tda"].type.type.reference, td)
+
+    def test_import_multiple_files(self):
+        with self.assertRaises(ProcessorException) as context:
+            self.processor.import_file("fidl/idl/P.fidl")
+            self.processor.import_file("fidl/idl2/P2.fidl")
+            self.assertEqual(str(context.exception),
+                             "Model 'definitions.fidl' not found.")

--- a/pyfranca/tests/test_franca_processor.py
+++ b/pyfranca/tests/test_franca_processor.py
@@ -3,6 +3,8 @@ Pyfranca processor tests.
 """
 
 import unittest
+import os
+import sys
 
 from pyfranca import ProcessorException, Processor, ast
 
@@ -551,9 +553,17 @@ class TestReferences(BaseTestCase):
         b = i.broadcasts["B"]
         self.assertEqual(b.out_args["tda"].type.type.reference, td)
 
-    def test_import_multiple_files(self):
+    def test_import_missing_files(self):
         with self.assertRaises(ProcessorException) as context:
             self.processor.import_file("fidl/idl/P.fidl")
             self.processor.import_file("fidl/idl2/P2.fidl")
             self.assertEqual(str(context.exception),
                              "Model 'definitions.fidl' not found.")
+
+    def test_import_multiple_files(self):
+        script_dir = os.path.dirname(os.path.realpath(__file__))
+        fidl_dir = os.path.join(script_dir, "fidl", "idl")
+        self.processor.package_paths.extend([fidl_dir])
+        self.processor.import_file("fidl/idl/P.fidl")
+        self.processor.import_file("fidl/idl2/P2.fidl")
+


### PR DESCRIPTION
Thanks for merging my last request. You are right that modifying self.package_paths is not the solution I wanted. But your code also modifies self.package_paths. If I understand your intention correctly I have found an bug in your code:

package_paths = self.package_paths
now package_paths is a reference to self.package_paths. I think your intention was to use a copy. I add a unittest to show the different behavior. I add 2 fidl packages. The first packages conatin of 2 files P.fidl and definitions.fidl. This is a valid package. The second packgage contains only P2.fidl. surprisingly p2.fidl tries to import definition.fidl from the first package. In this test I do not add any inlcude directories. So the import have to result in an error. But in the current code it found definition.fild because of the first import. With my modification it result in an "Module not found" exception.


