### PR TITLE
fix import file bug -->  normalize fspec path before using

### DIFF
--- a/pyfranca/franca_processor.py
+++ b/pyfranca/franca_processor.py
@@ -375,9 +375,15 @@ class Processor(object):
         :param package_path: Additional model path to search for imports.
         :return: The parsed ast.Package.
         """
-        if fspec in self.files:
-            # File already loaded.
-            return self.files[fspec]
+        withError = False
+
+        if withError:
+            # fspec could be an abs path or a relative one
+            # so comparing could fail altough both path are for the same file.
+            if fspec in self.files:
+                # File already loaded.
+                return self.files[fspec]
+
         if not os.path.exists(fspec):
             if os.path.isabs(fspec):
                 # Absolute specification
@@ -397,6 +403,16 @@ class Processor(object):
                 else:
                     raise ProcessorException(
                         "Model '{}' not found.".format(fspec))
+
+            if not withError:
+                fspec = os.path.abspath(fspec)  # normalize fpsec, remove all differences like / \
+
+                # at this position there is only one possible path for fspec
+                # independent if the function parameter was a relative or abs path.
+                if fspec in self.files:
+                    # File already loaded.
+                    return self.files[fspec]
+
         # Parse the file.
         parser = franca_parser.Parser()
         package = parser.parse_file(fspec)

--- a/pyfranca/tests/test_franca_processor.py
+++ b/pyfranca/tests/test_franca_processor.py
@@ -665,3 +665,4 @@ class TestReferences(BaseTestCase):
             }
         """)
         self.processor.import_file(fspec)
+        self.processor.import_file("./Type1.fidl")


### PR DESCRIPTION
in franca_processor the function import_file() has a bug.

Currently the function first check if fspec is already loaded and if not it try to  load it. The problem is that a fidl file could get import twice with different path --> abs path and relative path.

So the condition in line 378 coud fail even it is the same file.

Fix:
Befor checking if the module is already loaded I determind the absolut path of fspec and normalize it. So the condition is always true for the same fidl file.

I modified your unit test in test_franca_processor.py a bit.  Currently the test will fail because you try to import Type1.fidl twice. If you set variable withError  to False the test runs successfully.

Hopefully you can confirm this bug.