### PR TITLE
fix bug in import_file()

### DIFF
--- a/pyfranca/franca_processor.py
+++ b/pyfranca/franca_processor.py
@@ -408,10 +408,7 @@ class Processor(object):
         :return: The parsed ast.Package.
         """
         abs_fspec = os.path.abspath(fspec)
-        if abs_fspec in self.files:
-            # File already loaded.
-            return self.files[abs_fspec]
-        elif not self._exists(abs_fspec):
+        if not self._exists(abs_fspec):
             if os.path.isabs(fspec):
                 # Absolute specification
                 raise ProcessorException(
@@ -430,6 +427,11 @@ class Processor(object):
                 else:
                     raise ProcessorException(
                         "Model '{}' not found.".format(fspec))
+
+        if abs_fspec in self.files:
+            # File already loaded.
+            return self.files[abs_fspec]
+
         # Parse the file.
         parser = franca_parser.Parser()
         package = parser.parse_file(abs_fspec)

--- a/pyfranca/tests/test_franca_processor.py
+++ b/pyfranca/tests/test_franca_processor.py
@@ -663,3 +663,4 @@ class TestReferences(BaseTestCase):
             }
         """)
         self.processor.import_file(fspec)
+        self.processor.import_file("./Type1.fidl")


### PR DESCRIPTION
if fspec is a relative path it could be that a file is imported twice.

Fix:
First determine absolute path of fidl file and then checks if the file is already imported.