### PR TITLE
use namespace_references instead of package_references

### DIFF
--- a/pyfranca/__init__.py
+++ b/pyfranca/__init__.py
@@ -7,4 +7,4 @@ from pyfranca.franca_parser import ParserException, Parser
 from pyfranca.franca_processor import ProcessorException, Processor
 
 
-__version__ = "0.4.1"
+__version__ = "0.5.10000"

--- a/pyfranca/ast.py
+++ b/pyfranca/ast.py
@@ -103,6 +103,7 @@ class Namespace(object):
         self.maps = OrderedDict()
         self.constants = OrderedDict()
         self.comments = comments if comments else OrderedDict()
+        self.namespace_references = []
         if members:
             for member in members:
                 self._add_member(member)

--- a/pyfranca/franca_processor.py
+++ b/pyfranca/franca_processor.py
@@ -86,7 +86,7 @@ class Processor(object):
         pkg, ns, name = Processor.split_fqn(fqn)
 
         resolved_namespace = None
-        count = 0 # number of matches, 0 not found, 1 ok, >1 ambigous
+        count = 0 # number of matches, 0 not found, 1 ok, >1 ambiguous
         package_fqn = ""
 
         if pkg is not None:

--- a/pyfranca/franca_processor.py
+++ b/pyfranca/franca_processor.py
@@ -223,13 +223,12 @@ class Processor(object):
         elif isinstance(name, ast.ComplexType):
             self._update_complextype_references(name)
         elif isinstance(name, ast.Reference):
-            if not name.namespace:
-                name.namespace = namespace
             if not name.reference:
                 resolved_name = self.resolve(namespace, name.name)
                 name.reference = resolved_name
+                name.namespace = resolved_name.namespace
 
-                # remove package and namespcae from fqn.
+                # remove package and namespace from fqn.
                 # it is not necessary anymore -> information is preserved in the reference
                 pkg, ns, type_name = Processor.split_fqn(name.name)
                 name.name = type_name

--- a/pyfranca/franca_processor.py
+++ b/pyfranca/franca_processor.py
@@ -94,11 +94,10 @@ class Processor(object):
                 if name in typecollection:
                     return typecollection[name]
             # Look in imports
-            for package_import in namespace.package.imports:
-                if package_import.namespace_reference:
+            for namespace_import in namespace.namespace_references:
                     # Look in namespaces imported in the type's package
-                    if name in package_import.namespace_reference:
-                        return package_import.namespace_reference[name]
+                if name in namespace_import:
+                    return namespace_import[name]
         else:
             # This is an FQN
             if pkg == namespace.package.name:
@@ -109,17 +108,11 @@ class Processor(object):
             else:
                 # Look in typecollections of packages imported in the
                 #   type's package using FQNs.
-                for package_import in namespace.package.imports:
-                    if package_import.namespace == "{}.{}.*".format(pkg, ns):
-                        for typecollection in package_import.\
-                                package_reference.typecollections.values():
-                            if typecollection.name == ns and \
-                                    name in typecollection:
-                                return typecollection[name]
-                        for interface in package_import. \
-                                package_reference.interfaces.values():
-                            if name in interface:
-                                return interface[name]
+                for namespace_import in namespace.namespace_references:
+                    if (namespace_import.package.name == pkg) and \
+                            (namespace_import.name == ns) and \
+                            (name in namespace_import):
+                            return namespace_import[name]
         # Give up
         raise ProcessorException(
             "Unresolved reference '{}'.".format(fqn))
@@ -291,40 +284,59 @@ class Processor(object):
                     "Invalid interface reference '{}'.".format(
                         namespace.extends))
 
-    def _update_package_references(self, package):
+    def _update_namespaces_references(self, package, imported_namespace):
+        for package_namespace in package.typecollections.values():
+            package_namespace.namespace_references.append(imported_namespace)
+        for package_namespace in package.interfaces.values():
+            package_namespace.namespace_references.append(imported_namespace)
+
+    def _update_package_references(self, package, imported_package, package_import):
         """
         Update type references in a package.
 
         :param package: ast.Package object.
         """
-        for package_import in package.imports:
-            assert package_import.package_reference is not None
-            if package_import.namespace:
-                # Namespace import
-                package_reference = package_import.package_reference
-                if not package_import.namespace.endswith(".*"):
-                    raise ProcessorException(
-                        "Invalid namespace import {}.".format(
-                            package_import.namespace))
-                namespace_name = \
-                    package_import.namespace[len(package_reference.name) + 1:-2]
-                # Update namespace reference
-                if namespace_name in package_reference:
-                    namespace = package_reference[namespace_name]
-                    package_import.namespace_reference = namespace
-                else:
-                    raise ProcessorException(
-                        "Namespace '{}' not found.".format(
-                            package_import.namespace))
-            else:
-                # Model import
-                assert package_import.namespace_reference is None
-        for namespace in package.typecollections:
-            self._update_namespace_references(
-                package.typecollections[namespace])
-        for namespace in package.interfaces:
-            self._update_interface_references(
-                package.interfaces[namespace])
+
+        # Update import reference  but not for itself
+        package_import.package_reference = imported_package
+
+        do_import = False
+        if package_import.namespace:
+            # import only the specified namespace
+            if not package_import.namespace.endswith(".*"):
+                raise ProcessorException(
+                    "Invalid namespace import {}.".format(
+                        package_import.namespace))
+
+            fqn = package_import.namespace[:-2]
+            ns = self.basename(fqn)
+            p = self.packagename(fqn)
+            found = False
+            for imported_namespace in imported_package.typecollections.values():
+                if (imported_namespace.name == ns) and (imported_namespace.package.name == p):
+                    found = True
+                    package_import.namespace_reference = imported_namespace
+
+                    # reference namespace from imported package to all namespaces in this package
+                    self._update_namespaces_references(package, imported_namespace)
+
+            for imported_namespace in imported_package.interfaces.values():
+                if (imported_namespace.name == ns) and (imported_namespace.package.name == p):
+                    found = True
+                    package_import.namespace_reference = imported_namespace
+
+                    # reference namespace from imported package to all namespaces in this package
+                    self._update_namespaces_references(package, imported_namespace)
+            if not found:
+                raise ProcessorException(
+                    "Namespace '{}' not found.".format(
+                        package_import.namespace))
+        else:
+            # model import -> import all namespaces
+            for imported_namespace in imported_package.typecollections.values():
+                self._update_namespaces_references(package, imported_namespace)
+            for imported_namespace in imported_package.interfaces.values():
+                self._update_namespaces_references(package, imported_namespace)
 
     def import_package(self, fspec, package, references=None):
         """
@@ -336,12 +348,33 @@ class Processor(object):
         :param package: ast.Package object.
         :param references: A list of package references.
         """
+        # Check whether package is already imported
+        abs_fspec = os.path.abspath(fspec)
+
         if not isinstance(package, ast.Package):
             ValueError("Expected ast.Package as input.")
         if not references:
             references = []
-        # Check whether package is already imported
-        abs_fspec = os.path.abspath(fspec)
+        elif abs_fspec in references:
+            # todo maybe raise an exception, interrupt circular dependency
+            return
+
+        # Process package imports before merging the packages. Otherwise the package import are processed multiple times
+        # it is important here to use abs_fspec as reference, not the pacakge
+        # in order to determine which fspec is already processed.
+        fspec_dir = os.path.dirname(abs_fspec)
+        for package_import in package.imports:
+            imported_package = self.import_file(
+                package_import.file, references + [abs_fspec], fspec_dir)
+            self._update_package_references(package, imported_package, package_import)
+
+        for namespace in package.typecollections:
+            self._update_namespace_references(
+                package.typecollections[namespace])
+        for namespace in package.interfaces:
+            self._update_interface_references(
+                package.interfaces[namespace])
+
         if package.name in self.packages:
             if abs_fspec not in self.packages[package.name].files:
                 # Merge the new package into the already existing one.
@@ -356,42 +389,7 @@ class Processor(object):
             self.packages[package.name] = package
             # Register the package file in the processor.
             self.files[abs_fspec] = package
-        # Process package imports
-        fspec_dir = os.path.dirname(abs_fspec)
-        for package_import in package.imports:
-            imported_package = self.import_file(
-                package_import.file, references + [package.name], fspec_dir)
-            # Update import reference
-            package_import.package_reference = imported_package
-        # Update type references
-        self._update_package_references(package)
 
-    def import_string(self, fspec, fidl, references=None):
-        """
-        Parse an FIDL string and import it into the processor as a package.
-
-        The file specification will be treated as part of the real file-system and can overlay existing files.
-
-        If a file has already been imported, the corresponding package will be returned.
-
-        :param fspec: File specification of the package.
-        :param fidl: FIDL string.
-        :param references: A list of package references.
-        :return: The parsed ast.Package.
-        """
-        abs_fspec = os.path.abspath(fspec)
-        if abs_fspec in self._string_files:
-            # Already loaded.
-            return self.files[abs_fspec]
-        # Parse the string.
-        parser = franca_parser.Parser()
-        package = parser.parse(fidl)
-        package.files = [abs_fspec]
-        # Add the virtual specification to the list of imported string file.
-        self._string_files.append(abs_fspec)
-        # Import the package in the processor.
-        self.import_package(abs_fspec, package, references)
-        return package
 
     def _exists(self, fspec):
         """

--- a/pyfranca/franca_processor.py
+++ b/pyfranca/franca_processor.py
@@ -228,6 +228,11 @@ class Processor(object):
             if not name.reference:
                 resolved_name = self.resolve(namespace, name.name)
                 name.reference = resolved_name
+
+                # remove package and namespcae from fqn.
+                # it is not necessary anymore -> information is preserved in the reference
+                pkg, ns, type_name = Processor.split_fqn(name.name)
+                name.name = type_name
         elif isinstance(name, ast.Attribute):
             self._update_type_references(name.namespace, name.type)
         elif isinstance(name, ast.Method):

--- a/pyfranca/tests/fidl/idl3/P1.fidl
+++ b/pyfranca/tests/fidl/idl3/P1.fidl
@@ -1,0 +1,15 @@
+package P
+
+import P.T1.* from "common.fidl"
+
+
+interface I1 {
+	version { major 1 minor 0 }
+
+	method sendData
+	{
+		in {
+              T1Enum data1
+           }
+	}
+}

--- a/pyfranca/tests/fidl/idl3/P2.fidl
+++ b/pyfranca/tests/fidl/idl3/P2.fidl
@@ -1,0 +1,16 @@
+package P
+
+import P.T2.* from "common.fidl"
+
+
+interface I2 {
+	version { major 1 minor 0 }
+
+	method sendData
+	{
+		in {
+              T1Enum data1
+              T2Enum data2
+           }
+	}
+}

--- a/pyfranca/tests/fidl/idl3/common.fidl
+++ b/pyfranca/tests/fidl/idl3/common.fidl
@@ -1,0 +1,22 @@
+package P
+
+typeCollection T1 {
+    version { major 1 minor 0 }
+
+	enumeration T1Enum {
+		abc
+		def
+		ghi
+		jkm
+	}
+}
+
+typeCollection T2 {
+    version { major 1 minor 0 }
+
+	enumeration T2Enum {
+		rst
+		uvw
+		xyz
+	}
+}

--- a/pyfranca/tests/fidl/tmp/test.fidl
+++ b/pyfranca/tests/fidl/tmp/test.fidl
@@ -1,0 +1,7 @@
+
+            package P
+            interface I {
+                enumeration E { A B C }
+                enumeration E2 extends E { A E F }
+            }
+        

--- a/pyfranca/tests/test_franca_processor.py
+++ b/pyfranca/tests/test_franca_processor.py
@@ -654,6 +654,7 @@ class TestReferences(BaseTestCase):
         self.assertEqual(a.type.type.reference, td)
         m = i.methods["M"]
         self.assertEqual(m.in_args["tda"].type.type.reference, td)
+        self.assertEqual(isinstance(m.in_args["tda"].type, ast.Array), True)
         self.assertEqual(m.out_args["tda"].type.type.reference, td)
         b = i.broadcasts["B"]
         self.assertEqual(b.out_args["tda"].type.type.reference, td)
@@ -880,21 +881,23 @@ class TestReferences(BaseTestCase):
             self.assertEqual(b2.type.name, "A")
             self.assertEqual(b2.type.reference, a)
 
-            b = self.processor.packages["P2"].interfaces["I"].typedefs["C"]
-            self.assertTrue(isinstance(b.type, ast.Reference))
-            self.assertEqual(b.type.name, "A2")
-            self.assertEqual(b.type.reference, a2)
-            b2 = self.processor.packages["P2"].interfaces["I"].typedefs["C2"]
-            self.assertTrue(isinstance(b2.type, ast.Reference))
-            self.assertEqual(b2.type.name, "A")
-            self.assertEqual(b2.type.reference, a)
+            c = self.processor.packages["P2"].interfaces["I"].typedefs["C"]
+            self.assertTrue(isinstance(c.type, ast.Reference))
+            self.assertEqual(c.type.name, "A2")
+            self.assertEqual(c.type.reference, a2)
+            self.assertEqual(c.type.reference.namespace, self.processor.packages["P2"].typecollections["TC2"])
 
-            b = self.processor.packages["P2"].interfaces["I"].typedefs["D"]
-            self.assertTrue(isinstance(b.type, ast.Reference))
-            self.assertEqual(b.type.name, "A2")
-            self.assertEqual(b.type.reference, a2)
-            b2 = self.processor.packages["P2"].interfaces["I"].typedefs["D2"]
-            self.assertTrue(isinstance(b2.type, ast.Reference))
-            self.assertEqual(b2.type.name, "A")
-            self.assertEqual(b2.type.reference, a)
+            c2 = self.processor.packages["P2"].interfaces["I"].typedefs["C2"]
+            self.assertTrue(isinstance(c2.type, ast.Reference))
+            self.assertEqual(c2.type.name, "A")
+            self.assertEqual(c2.type.reference, a)
+
+            d = self.processor.packages["P2"].interfaces["I"].typedefs["D"]
+            self.assertTrue(isinstance(d.type, ast.Reference))
+            self.assertEqual(d.type.name, "A2")
+            self.assertEqual(d.type.reference, a2)
+            d2 = self.processor.packages["P2"].interfaces["I"].typedefs["D2"]
+            self.assertTrue(isinstance(d2.type, ast.Reference))
+            self.assertEqual(d2.type.name, "A")
+            self.assertEqual(d2.type.reference, a)
 

--- a/pyfranca/tests/test_franca_processor.py
+++ b/pyfranca/tests/test_franca_processor.py
@@ -841,3 +841,60 @@ class TestReferences(BaseTestCase):
         self.assertEqual(self.processor.packages['P'].interfaces["I"].methods["getData"].
                          out_args["out_t2"].type.reference.namespace.name, "T2")
 
+    def test_type_notations(self):
+            self.tmp_fidl("test.fidl", """
+                package P
+                typeCollection TC {
+                    typedef A is Int32
+                }
+            """)
+            fspec = self.tmp_fidl("test2.fidl", """
+                package P2
+                import P.TC.* from "test.fidl"
+                typeCollection TC2 {
+                    typedef A2 is UInt32
+                }
+                interface I {
+                    typedef B is P2.TC2.A2
+                    typedef B2 is P.TC.A
+
+                    typedef C is TC2.A2
+                    typedef C2 is TC.A
+
+                    typedef D is A2
+                    typedef D2 is A
+                }
+            """)
+            self.processor.import_file(fspec)
+
+            a = self.processor.packages["P"].typecollections["TC"].typedefs["A"]
+            self.assertTrue(isinstance(a.type, ast.Int32))
+            a2 = self.processor.packages["P2"].typecollections["TC2"].typedefs["A2"]
+            self.assertTrue(isinstance(a2.type, ast.UInt32))
+            b = self.processor.packages["P2"].interfaces["I"].typedefs["B"]
+            self.assertTrue(isinstance(b.type, ast.Reference))
+            self.assertEqual(b.type.name, "A2")
+            self.assertEqual(b.type.reference, a2)
+            b2 = self.processor.packages["P2"].interfaces["I"].typedefs["B2"]
+            self.assertTrue(isinstance(b2.type, ast.Reference))
+            self.assertEqual(b2.type.name, "A")
+            self.assertEqual(b2.type.reference, a)
+
+            b = self.processor.packages["P2"].interfaces["I"].typedefs["C"]
+            self.assertTrue(isinstance(b.type, ast.Reference))
+            self.assertEqual(b.type.name, "A2")
+            self.assertEqual(b.type.reference, a2)
+            b2 = self.processor.packages["P2"].interfaces["I"].typedefs["C2"]
+            self.assertTrue(isinstance(b2.type, ast.Reference))
+            self.assertEqual(b2.type.name, "A")
+            self.assertEqual(b2.type.reference, a)
+
+            b = self.processor.packages["P2"].interfaces["I"].typedefs["D"]
+            self.assertTrue(isinstance(b.type, ast.Reference))
+            self.assertEqual(b.type.name, "A2")
+            self.assertEqual(b.type.reference, a2)
+            b2 = self.processor.packages["P2"].interfaces["I"].typedefs["D2"]
+            self.assertTrue(isinstance(b2.type, ast.Reference))
+            self.assertEqual(b2.type.name, "A")
+            self.assertEqual(b2.type.reference, a)
+

--- a/pyfranca/tests/test_franca_processor.py
+++ b/pyfranca/tests/test_franca_processor.py
@@ -235,7 +235,7 @@ class TestReferences(BaseTestCase):
         self.assertTrue(isinstance(a.type, ast.Int32))
         b = self.processor.packages["P"].typecollections["TC"].typedefs["B"]
         self.assertTrue(isinstance(b.type, ast.Reference))
-        self.assertEqual(b.type.name, "P.TC.A")
+        self.assertEqual(b.type.name, "A")
         self.assertEqual(b.type.reference, a)
 
     def test_reference_to_different_namespace(self):
@@ -321,11 +321,11 @@ class TestReferences(BaseTestCase):
         self.assertTrue(isinstance(a2.type, ast.UInt32))
         b = self.processor.packages["P2"].interfaces["I"].typedefs["B"]
         self.assertTrue(isinstance(b.type, ast.Reference))
-        self.assertEqual(b.type.name, "P2.TC.A")
+        self.assertEqual(b.type.name, "A")
         self.assertEqual(b.type.reference, a2)
         b2 = self.processor.packages["P2"].interfaces["I"].typedefs["B2"]
         self.assertTrue(isinstance(b2.type, ast.Reference))
-        self.assertEqual(b2.type.name, "P.TC.A")
+        self.assertEqual(b2.type.name, "A")
         self.assertEqual(b2.type.reference, a)
 
     def test_interface_visibility(self):
@@ -353,7 +353,7 @@ class TestReferences(BaseTestCase):
         self.assertTrue(isinstance(a2.type, ast.UInt32))
         b = self.processor.packages["P2"].typecollections["TC"].typedefs["B"]
         self.assertTrue(isinstance(b.type, ast.Reference))
-        self.assertEqual(b.type.name, "TC.A")
+        self.assertEqual(b.type.name, "A")
         self.assertEqual(b.type.reference, a)
 
     def test_unresolved_reference_in_typedef(self):

--- a/pyfranca/tests/test_franca_processor.py
+++ b/pyfranca/tests/test_franca_processor.py
@@ -86,17 +86,20 @@ class TestImports(BaseTestCase):
     """Test import related features."""
 
     def test_basic(self):
-        self.processor.import_string("test.fidl", """
+        fspec = self.tmp_fidl("test.fidl", """
             package P
         """)
-        self.processor.import_string("test2.fidl", """
+        fspec2 = self.tmp_fidl("test2.fidl", """
             package P2
         """)
+        self.processor.import_file(fspec)
+        self.processor.import_file(fspec2)
+
         # Verify file access
         self.assertEqual(len(self.processor.files), 2)
-        p = self.processor.files[os.path.abspath("test.fidl")]
+        p = self.processor.files[fspec]
         self.assertEqual(p.name, "P")
-        p2 = self.processor.files[os.path.abspath("test2.fidl")]
+        p2 = self.processor.files[fspec2]
         self.assertEqual(p2.name, "P2")
         # Verify package access
         self.assertEqual(len(self.processor.packages), 2)
@@ -107,31 +110,37 @@ class TestImports(BaseTestCase):
 
     def test_import_nonexistent_model(self):
         with self.assertRaises(ProcessorException) as context:
-            self.processor.import_string("test.fidl", """
+            fspec = self.tmp_fidl("test.fidl", """
                 package P
                 import model "nosuch.fidl"
             """)
+            self.processor.import_file(fspec)
+
         self.assertEqual(str(context.exception),
                          "Model 'nosuch.fidl' not found.")
 
     def test_import_nonexistent_model2(self):
         with self.assertRaises(ProcessorException) as context:
-            self.processor.import_string("test.fidl", """
+            fspec = self.tmp_fidl ("test.fidl", """
                 package P
                 import P.Nonexistent.* from "nosuch.fidl"
             """)
+            self.processor.import_file(fspec)
         self.assertEqual(str(context.exception),
                          "Model 'nosuch.fidl' not found.")
 
     def test_import_nonexistent_namespace(self):
         with self.assertRaises(ProcessorException) as context:
-            self.processor.import_string("test.fidl", """
+            self.tmp_fidl ("test.fidl", """
                 package P
             """)
-            self.processor.import_string("test2.fidl", """
+            fspec = self.tmp_fidl ("test2.fidl", """
                 package P2
                 import P.Nonexistent.* from "test.fidl"
             """)
+            self.processor.import_file(fspec)
+            print("Hello")
+
         self.assertEqual(str(context.exception),
                          "Namespace 'P.Nonexistent.*' not found.")
 
@@ -152,31 +161,36 @@ class TestPackagesInMultipleFiles(BaseTestCase):
     """Support for packages in multiple files"""
 
     def test_package_in_multiple_files(self):
-        self.processor.import_string("test.fidl", """
+        fspec = self.tmp_fidl ("test.fidl", """
             package P
         """)
-        self.processor.import_string("test2.fidl", """
+        fspec2 = self.tmp_fidl ("test2.fidl", """
             package P
         """)
+        self.processor.import_file(fspec)
+        self.processor.import_file(fspec2)
         p = self.processor.packages["P"]
-        self.assertEqual(p.files, [os.path.abspath("test.fidl"), os.path.abspath("test2.fidl")])
+        self.assertEqual(p.files, [fspec, fspec2])
 
     def test_package_in_multiple_files_reuse(self):
-        self.processor.import_string("test.fidl", """
+        fspec = self.tmp_fidl ("test.fidl", """
             package P
             typeCollection TC {
                 typedef A is Int32
             }
         """)
-        self.processor.import_string("test2.fidl", """
+        fspec2 = self.tmp_fidl ("test2.fidl", """
             package P
             import P.TC.* from "test.fidl"
             interface I {
                 typedef B is A
             }
         """)
+        self.processor.import_file(fspec)
+        self.processor.import_file(fspec2)
+
         p = self.processor.packages["P"]
-        self.assertEqual(p.files, [os.path.abspath("test.fidl"), os.path.abspath("test2.fidl")])
+        self.assertEqual(p.files, [fspec, fspec2])
         a = p.typecollections["TC"].typedefs["A"]
         self.assertEqual(a.namespace.package, p)
         self.assertTrue(isinstance(a.type, ast.Int32))
@@ -191,13 +205,15 @@ class TestReferences(BaseTestCase):
     """Test type references."""
 
     def test_reference_to_same_namespace(self):
-        self.processor.import_string("test.fidl", """
+        fspec = self.tmp_fidl ("test.fidl", """
             package P
             typeCollection TC {
                 typedef A is Int32
                 typedef B is A
             }
         """)
+        self.processor.import_file(fspec)
+
         a = self.processor.packages["P"].typecollections["TC"].typedefs["A"]
         self.assertTrue(isinstance(a.type, ast.Int32))
         b = self.processor.packages["P"].typecollections["TC"].typedefs["B"]
@@ -206,13 +222,15 @@ class TestReferences(BaseTestCase):
         self.assertEqual(b.type.reference, a)
 
     def test_fqn_reference(self):
-        self.processor.import_string("test.fidl", """
+        fspec = self.tmp_fidl ("test.fidl", """
             package P
             typeCollection TC {
                 typedef A is Int32
                 typedef B is P.TC.A
             }
         """)
+        self.processor.import_file(fspec)
+
         a = self.processor.packages["P"].typecollections["TC"].typedefs["A"]
         self.assertTrue(isinstance(a.type, ast.Int32))
         b = self.processor.packages["P"].typecollections["TC"].typedefs["B"]
@@ -221,7 +239,7 @@ class TestReferences(BaseTestCase):
         self.assertEqual(b.type.reference, a)
 
     def test_reference_to_different_namespace(self):
-        self.processor.import_string("test.fidl", """
+        fspec = self.tmp_fidl ("test.fidl", """
             package P
             typeCollection TC {
                 typedef A is Int32
@@ -230,6 +248,8 @@ class TestReferences(BaseTestCase):
                 typedef B is A
             }
         """)
+        self.processor.import_file(fspec)
+
         a = self.processor.packages["P"].typecollections["TC"].typedefs["A"]
         self.assertTrue(isinstance(a.type, ast.Int32))
         b = self.processor.packages["P"].interfaces["I"].typedefs["B"]
@@ -238,19 +258,21 @@ class TestReferences(BaseTestCase):
         self.assertEqual(b.type.reference, a)
 
     def test_reference_to_different_model(self):
-        self.processor.import_string("test.fidl", """
+        self.tmp_fidl ("test.fidl", """
             package P
             typeCollection TC {
                 typedef A is Int32
             }
         """)
-        self.processor.import_string("test2.fidl", """
+        fspec = self.tmp_fidl ("test2.fidl", """
             package P2
             import P.TC.* from "test.fidl"
             interface I {
                 typedef B is A
             }
         """)
+        self.processor.import_file(fspec)
+
         a = self.processor.packages["P"].typecollections["TC"].typedefs["A"]
         self.assertTrue(isinstance(a.type, ast.Int32))
         b = self.processor.packages["P2"].interfaces["I"].typedefs["B"]
@@ -261,24 +283,26 @@ class TestReferences(BaseTestCase):
     @unittest.skip("Currently not checked.")
     def test_circular_reference(self):
         with self.assertRaises(ProcessorException) as context:
-            self.processor.import_string("test.fidl", """
+            fspec = self.tmp_fidl ("test.fidl", """
                 package P
                 typeCollection TC {
                     typedef A is B
                     typedef B is A
                 }
             """)
+            self.processor.import_file(fspec)
+
         self.assertEqual(str(context.exception),
                          "Circular reference 'B'.")
 
     def test_reference_priority(self):
-        self.processor.import_string("test.fidl", """
+        self.tmp_fidl ("test.fidl", """
             package P
             typeCollection TC {
                 typedef A is Int32
             }
         """)
-        self.processor.import_string("test2.fidl", """
+        fspec = self.tmp_fidl ("test2.fidl", """
             package P2
             import P.TC.* from "test.fidl"
             typeCollection TC {
@@ -289,6 +313,8 @@ class TestReferences(BaseTestCase):
                 typedef B2 is P.TC.A
             }
         """)
+        self.processor.import_file(fspec)
+
         a = self.processor.packages["P"].typecollections["TC"].typedefs["A"]
         self.assertTrue(isinstance(a.type, ast.Int32))
         a2 = self.processor.packages["P2"].typecollections["TC"].typedefs["A"]
@@ -303,13 +329,13 @@ class TestReferences(BaseTestCase):
         self.assertEqual(b2.type.reference, a)
 
     def test_interface_visibility(self):
-        self.processor.import_string("test.fidl", """
+        self.tmp_fidl ("test.fidl", """
             package P
             typeCollection TC {
                 typedef A is Int32
             }
         """)
-        self.processor.import_string("test2.fidl", """
+        fspec = self.tmp_fidl ("test2.fidl", """
             package P2
             import P.TC.* from "test.fidl"
             interface I {
@@ -319,6 +345,8 @@ class TestReferences(BaseTestCase):
                 typedef B is A
             }
         """)
+        self.processor.import_file(fspec)
+
         a = self.processor.packages["P"].typecollections["TC"].typedefs["A"]
         self.assertTrue(isinstance(a.type, ast.Int32))
         a2 = self.processor.packages["P2"].interfaces["I"].typedefs["A"]
@@ -330,18 +358,20 @@ class TestReferences(BaseTestCase):
 
     def test_unresolved_reference_in_typedef(self):
         with self.assertRaises(ProcessorException) as context:
-            self.processor.import_string("test.fidl", """
+            fspec = self.tmp_fidl ("test.fidl", """
                 package P
                 typeCollection TC {
                     typedef TD is Unknown
                 }
             """)
+            self.processor.import_file(fspec)
+
         self.assertEqual(str(context.exception),
                          "Unresolved reference 'Unknown'.")
 
     def test_unresolved_reference_in_struct(self):
         with self.assertRaises(ProcessorException) as context:
-            self.processor.import_string("test.fidl", """
+            fspec = self.tmp_fidl ("test.fidl", """
                 package P
                 typeCollection TC {
                     struct S {
@@ -349,105 +379,125 @@ class TestReferences(BaseTestCase):
                     }
                 }
             """)
+            self.processor.import_file(fspec)
+
         self.assertEqual(str(context.exception),
                          "Unresolved reference 'Unknown'.")
 
     def test_unresolved_reference_in_array(self):
         with self.assertRaises(ProcessorException) as context:
-            self.processor.import_string("test.fidl", """
+            fspec = self.tmp_fidl ("test.fidl", """
                 package P
                 typeCollection TC {
                     array A of Unknown
                 }
             """)
+            self.processor.import_file(fspec)
+
         self.assertEqual(str(context.exception),
                          "Unresolved reference 'Unknown'.")
 
     def test_unresolved_reference_in_map(self):
         with self.assertRaises(ProcessorException) as context:
-            self.processor.import_string("test.fidl", """
+            fspec = self.tmp_fidl ("test.fidl", """
                 package P
                 typeCollection TC {
                     map M { Unknown to Int32 }
                 }
             """)
+            self.processor.import_file(fspec)
+
         self.assertEqual(str(context.exception),
                          "Unresolved reference 'Unknown'.")
 
     def test_unresolved_reference_in_map2(self):
         with self.assertRaises(ProcessorException) as context:
-            self.processor.import_string("test.fidl", """
+            fspec = self.tmp_fidl ("test.fidl", """
                 package P
                 typeCollection TC {
                     map M { Int32 to Unknown }
                 }
             """)
+            self.processor.import_file(fspec)
+
         self.assertEqual(str(context.exception),
                          "Unresolved reference 'Unknown'.")
 
     def test_unresolved_reference_in_attribute(self):
         with self.assertRaises(ProcessorException) as context:
-            self.processor.import_string("test.fidl", """
+            fspec = self.tmp_fidl ("test.fidl", """
                 package P
                 interface I {
                     attribute Unknown A
                 }
             """)
+            self.processor.import_file(fspec)
+
         self.assertEqual(str(context.exception),
                          "Unresolved reference 'Unknown'.")
 
     def test_unresolved_reference_in_method(self):
         with self.assertRaises(ProcessorException) as context:
-            self.processor.import_string("test.fidl", """
+            fspec = self.tmp_fidl ("test.fidl", """
                 package P
                 interface I {
                     method M { in { Unknown a } }
                 }
             """)
+            self.processor.import_file(fspec)
+
         self.assertEqual(str(context.exception),
                          "Unresolved reference 'Unknown'.")
 
     def test_unresolved_reference_in_method2(self):
         with self.assertRaises(ProcessorException) as context:
-            self.processor.import_string("test.fidl", """
+            fspec = self.tmp_fidl ("test.fidl", """
                 package P
                 interface I {
                     method M { out { Unknown a } }
                 }
             """)
+            self.processor.import_file(fspec)
+
         self.assertEqual(str(context.exception),
                          "Unresolved reference 'Unknown'.")
 
     def test_unresolved_reference_in_method3(self):
         with self.assertRaises(ProcessorException) as context:
-            self.processor.import_string("test.fidl", """
+            fspec = self.tmp_fidl ("test.fidl", """
                 package P
                 interface I {
                     method M { error Unknown }
                 }
             """)
+            self.processor.import_file(fspec)
+
         self.assertEqual(str(context.exception),
                          "Unresolved reference 'Unknown'.")
 
     def test_unresolved_reference_in_broadcast(self):
         with self.assertRaises(ProcessorException) as context:
-            self.processor.import_string("test.fidl", """
+            fspec = self.tmp_fidl ("test.fidl", """
                 package P
                 interface I {
                     broadcast B { out { Unknown a } }
                 }
             """)
+            self.processor.import_file(fspec)
+
         self.assertEqual(str(context.exception),
                          "Unresolved reference 'Unknown'.")
 
     def test_method_error_reference(self):
-        self.processor.import_string("test.fidl", """
+        fspec = self.tmp_fidl ("test.fidl", """
             package P
             interface I {
                 enumeration E { A B C }
                 method M { error E }
             }
         """)
+        self.processor.import_file(fspec)
+
         e = self.processor.packages["P"].interfaces["I"].enumerations["E"]
         m = self.processor.packages["P"].interfaces["I"].methods["M"]
         me = m.errors
@@ -456,71 +506,83 @@ class TestReferences(BaseTestCase):
 
     def test_invalid_method_error_reference(self):
         with self.assertRaises(ProcessorException) as context:
-            self.processor.import_string("test.fidl", """
+            fspec = self.tmp_fidl ("test.fidl", """
                 package P
                 interface I {
                     typedef E is String
                     method M { error E }
                 }
             """)
+            self.processor.import_file(fspec)
+
         self.assertEqual(str(context.exception),
                          "Invalid error reference 'E'.")
 
     def test_enumeration_extension(self):
-        self.processor.import_string("test.fidl", """
+        fspec = self.tmp_fidl ("test.fidl", """
             package P
             interface I {
                 enumeration E { A B C }
                 enumeration E2 extends E { D E F }
             }
         """)
+        self.processor.import_file(fspec)
+
         e = self.processor.packages["P"].interfaces["I"].enumerations["E"]
         e2 = self.processor.packages["P"].interfaces["I"].enumerations["E2"]
         self.assertEqual(e2.reference, e)
 
     def test_invalid_enumeration_extension(self):
         with self.assertRaises(ProcessorException) as context:
-            self.processor.import_string("test.fidl", """
+            fspec = self.tmp_fidl ("test.fidl", """
                 package P
                 interface I {
                     typedef E is String
                     enumeration E2 extends E { D E F }
                 }
             """)
+            self.processor.import_file(fspec)
+
         self.assertEqual(str(context.exception),
                          "Invalid enumeration reference 'E'.")
 
     def test_struct_extension(self):
-        self.processor.import_string("test.fidl", """
+        fspec = self.tmp_fidl ("test.fidl", """
             package P
             interface I {
                 struct S { Int32 a }
                 struct S2 extends S { Int32 b }
             }
         """)
+        self.processor.import_file(fspec)
+
         s = self.processor.packages["P"].interfaces["I"].structs["S"]
         s2 = self.processor.packages["P"].interfaces["I"].structs["S2"]
         self.assertEqual(s2.reference, s)
 
     def test_invalid_struct_extension(self):
         with self.assertRaises(ProcessorException) as context:
-            self.processor.import_string("test.fidl", """
+            fspec = self.tmp_fidl ("test.fidl", """
                 package P
                 interface I {
                     typedef S is String
                     struct S2 extends S { Int32 b }
                 }
             """)
+            self.processor.import_file(fspec)
+
         self.assertEqual(str(context.exception),
                          "Invalid struct reference 'S'.")
 
     def test_interface_extension(self):
-        self.processor.import_string("test.fidl", """
+        fspec = self.tmp_fidl ("test.fidl", """
             package P
             interface I { }
             interface I2 extends I { }
             interface I3 extends P.I { }
         """)
+        self.processor.import_file(fspec)
+
         i = self.processor.packages["P"].interfaces["I"]
         i2 = self.processor.packages["P"].interfaces["I2"]
         self.assertEqual(i2.reference, i)
@@ -528,16 +590,18 @@ class TestReferences(BaseTestCase):
         self.assertEqual(i3.reference, i)
 
     def test_interface_extension2(self):
-        self.processor.import_string("test.fidl", """
+        self.tmp_fidl ("test.fidl", """
             package P
             interface I { }
         """)
-        self.processor.import_string("test2.fidl", """
+        fspec = self.tmp_fidl ("test2.fidl", """
             package P2
             import model "test.fidl"
             interface I2 extends I { }
             interface I3 extends P.I { }
         """)
+        self.processor.import_file(fspec)
+
         i = self.processor.packages["P"].interfaces["I"]
         i2 = self.processor.packages["P2"].interfaces["I2"]
         self.assertEqual(i2.reference, i)
@@ -546,16 +610,18 @@ class TestReferences(BaseTestCase):
 
     def test_invalid_interface_extension(self):
         with self.assertRaises(ProcessorException) as context:
-            self.processor.import_string("test.fidl", """
+            fspec = self.tmp_fidl ("test.fidl", """
                 package P
                 typeCollection TC { typedef I is Int32 }
                 interface I2 extends I { }
             """)
+            self.processor.import_file(fspec)
+
         self.assertEqual(str(context.exception),
                          "Unresolved namespace reference 'I'.")
 
     def test_anonymous_array_references(self):
-        self.processor.import_string("test.fidl", """
+        fspec = self.tmp_fidl ("test.fidl", """
             package P
             typeCollection TC {
                 typedef TD is Int32
@@ -570,6 +636,8 @@ class TestReferences(BaseTestCase):
                 broadcast B { out { TD[] tda } }
             }
         """)
+        self.processor.import_file(fspec)
+
         tc = self.processor.packages["P"].typecollections["TC"]
         td = tc.typedefs["TD"]
         tda = tc.typedefs["TDA"]
@@ -594,20 +662,20 @@ class TestReferences(BaseTestCase):
         # P.fidl references definitions.fidl but it is not in the package path.
         with self.assertRaises(ProcessorException) as context:
             self.processor.import_file(
-                os.path.join("pyfranca", "tests", "fidl", "idl", "P.fidl"))
+                os.path.join(self.get_spec("idl"), "P.fidl"))
             self.processor.import_file(
-                os.path.join("pyfranca", "tests", "fidl", "idl2", "P2.fidl"))
+                os.path.join(self.get_spec("idl2"), "P2.fidl"))
         self.assertEqual(str(context.exception),
                          "Model 'definitions.fidl' not found.")
 
     def test_import_multiple_files(self):
-        script_dir = os.path.dirname(os.path.realpath(__file__))
-        fidl_dir = os.path.join(script_dir, "fidl", "idl")
+        fidl_dir = self.get_spec("idl")
         self.processor.package_paths.append(fidl_dir)
         self.processor.import_file(
-            os.path.join("P.fidl"))
+            os.path.join(fidl_dir, "P.fidl"))
         self.processor.import_file(
-            os.path.join("pyfranca", "tests", "fidl", "idl2", "P2.fidl"))
+            os.path.join(self.get_spec("idl2"), "P2.fidl"))
+
 
     def test_import_file_chain(self):
         fspec = self.tmp_fidl("P.fidl", """
@@ -664,3 +732,37 @@ class TestReferences(BaseTestCase):
         """)
         self.processor.import_file(fspec)
         self.processor.import_file("./Type1.fidl")
+
+        self.assertEqual(self.processor.packages["P"].name, "P")
+        self.assertEqual(self.processor.packages['P'].interfaces["I"].methods["getData"].
+                         out_args["outVal"].type.reference.namespace.name, "Type1")
+        self.assertEqual(self.processor.packages['P'].interfaces["I"].methods["getData"].
+                         out_args["outVal"].type.reference.namespace.package.name, "P")
+
+        self.assertEqual(self.processor.packages['P'].interfaces["I"].methods["getData"].
+                         in_args["inVal"].type.reference.namespace.name, "Type2")
+        self.assertEqual(self.processor.packages['P'].interfaces["I"].methods["getData"].
+                         in_args["inVal"].type.reference.namespace.package.name, "P")
+
+        self.assertEqual(self.processor.packages['P'].interfaces["I"].namespace_references[0],
+                         self.processor.packages['P'].typecollections["Type1"])
+        self.assertEqual(self.processor.packages['P'].interfaces["I"].namespace_references[1],
+                         self.processor.packages['P'].typecollections["Type2"])
+
+        self.assertEqual(
+            self.processor.packages['P'].interfaces["I"].namespace_references[0].namespace_references[0].name, "Common")
+        self.assertEqual(
+            self.processor.packages['P'].interfaces["I"].namespace_references[1].namespace_references[0].name, "Common")
+
+        # check that interface "I" has no reference to namespace "Common" --> no transitive imports
+        self.assertEqual(len(self.processor.packages['P'].interfaces["I"].namespace_references), 2)
+
+    def test_invalid_type_use(self):
+        # P.fidl references definitions.fidl but it is not in the package path.
+        with self.assertRaises(ProcessorException) as context:
+            self.processor.import_file(
+                os.path.join(self.get_spec("idl3"), "P1.fidl"))
+            self.processor.import_file(
+                os.path.join(self.get_spec("idl3"), "P2.fidl"))
+        self.assertEqual(str(context.exception),
+                         "Unresolved reference 'T1Enum'.")

--- a/pyfranca/tests/test_franca_processor.py
+++ b/pyfranca/tests/test_franca_processor.py
@@ -121,7 +121,7 @@ class TestImports(BaseTestCase):
 
     def test_import_nonexistent_model2(self):
         with self.assertRaises(ProcessorException) as context:
-            fspec = self.tmp_fidl ("test.fidl", """
+            fspec = self.tmp_fidl("test.fidl", """
                 package P
                 import P.Nonexistent.* from "nosuch.fidl"
             """)
@@ -131,10 +131,10 @@ class TestImports(BaseTestCase):
 
     def test_import_nonexistent_namespace(self):
         with self.assertRaises(ProcessorException) as context:
-            self.tmp_fidl ("test.fidl", """
+            self.tmp_fidl("test.fidl", """
                 package P
             """)
-            fspec = self.tmp_fidl ("test2.fidl", """
+            fspec = self.tmp_fidl("test2.fidl", """
                 package P2
                 import P.Nonexistent.* from "test.fidl"
             """)
@@ -161,10 +161,10 @@ class TestPackagesInMultipleFiles(BaseTestCase):
     """Support for packages in multiple files"""
 
     def test_package_in_multiple_files(self):
-        fspec = self.tmp_fidl ("test.fidl", """
+        fspec = self.tmp_fidl("test.fidl", """
             package P
         """)
-        fspec2 = self.tmp_fidl ("test2.fidl", """
+        fspec2 = self.tmp_fidl("test2.fidl", """
             package P
         """)
         self.processor.import_file(fspec)
@@ -173,13 +173,13 @@ class TestPackagesInMultipleFiles(BaseTestCase):
         self.assertEqual(p.files, [fspec, fspec2])
 
     def test_package_in_multiple_files_reuse(self):
-        fspec = self.tmp_fidl ("test.fidl", """
+        fspec = self.tmp_fidl("test.fidl", """
             package P
             typeCollection TC {
                 typedef A is Int32
             }
         """)
-        fspec2 = self.tmp_fidl ("test2.fidl", """
+        fspec2 = self.tmp_fidl("test2.fidl", """
             package P
             import P.TC.* from "test.fidl"
             interface I {
@@ -205,7 +205,7 @@ class TestReferences(BaseTestCase):
     """Test type references."""
 
     def test_reference_to_same_namespace(self):
-        fspec = self.tmp_fidl ("test.fidl", """
+        fspec = self.tmp_fidl("test.fidl", """
             package P
             typeCollection TC {
                 typedef A is Int32
@@ -222,7 +222,7 @@ class TestReferences(BaseTestCase):
         self.assertEqual(b.type.reference, a)
 
     def test_fqn_reference(self):
-        fspec = self.tmp_fidl ("test.fidl", """
+        fspec = self.tmp_fidl("test.fidl", """
             package P
             typeCollection TC {
                 typedef A is Int32
@@ -239,7 +239,7 @@ class TestReferences(BaseTestCase):
         self.assertEqual(b.type.reference, a)
 
     def test_reference_to_different_namespace(self):
-        fspec = self.tmp_fidl ("test.fidl", """
+        fspec = self.tmp_fidl("test.fidl", """
             package P
             typeCollection TC {
                 typedef A is Int32
@@ -258,13 +258,13 @@ class TestReferences(BaseTestCase):
         self.assertEqual(b.type.reference, a)
 
     def test_reference_to_different_model(self):
-        self.tmp_fidl ("test.fidl", """
+        self.tmp_fidl("test.fidl", """
             package P
             typeCollection TC {
                 typedef A is Int32
             }
         """)
-        fspec = self.tmp_fidl ("test2.fidl", """
+        fspec = self.tmp_fidl("test2.fidl", """
             package P2
             import P.TC.* from "test.fidl"
             interface I {
@@ -283,7 +283,7 @@ class TestReferences(BaseTestCase):
     @unittest.skip("Currently not checked.")
     def test_circular_reference(self):
         with self.assertRaises(ProcessorException) as context:
-            fspec = self.tmp_fidl ("test.fidl", """
+            fspec = self.tmp_fidl("test.fidl", """
                 package P
                 typeCollection TC {
                     typedef A is B
@@ -296,20 +296,20 @@ class TestReferences(BaseTestCase):
                          "Circular reference 'B'.")
 
     def test_reference_priority(self):
-        self.tmp_fidl ("test.fidl", """
+        self.tmp_fidl("test.fidl", """
             package P
             typeCollection TC {
                 typedef A is Int32
             }
         """)
-        fspec = self.tmp_fidl ("test2.fidl", """
+        fspec = self.tmp_fidl("test2.fidl", """
             package P2
             import P.TC.* from "test.fidl"
             typeCollection TC {
                 typedef A is UInt32
             }
             interface I {
-                typedef B is A
+                typedef B is P2.TC.A
                 typedef B2 is P.TC.A
             }
         """)
@@ -321,7 +321,7 @@ class TestReferences(BaseTestCase):
         self.assertTrue(isinstance(a2.type, ast.UInt32))
         b = self.processor.packages["P2"].interfaces["I"].typedefs["B"]
         self.assertTrue(isinstance(b.type, ast.Reference))
-        self.assertEqual(b.type.name, "A")
+        self.assertEqual(b.type.name, "P2.TC.A")
         self.assertEqual(b.type.reference, a2)
         b2 = self.processor.packages["P2"].interfaces["I"].typedefs["B2"]
         self.assertTrue(isinstance(b2.type, ast.Reference))
@@ -329,20 +329,20 @@ class TestReferences(BaseTestCase):
         self.assertEqual(b2.type.reference, a)
 
     def test_interface_visibility(self):
-        self.tmp_fidl ("test.fidl", """
+        self.tmp_fidl("test.fidl", """
             package P
             typeCollection TC {
                 typedef A is Int32
             }
         """)
-        fspec = self.tmp_fidl ("test2.fidl", """
+        fspec = self.tmp_fidl("test2.fidl", """
             package P2
             import P.TC.* from "test.fidl"
             interface I {
                 typedef A is UInt32
             }
             typeCollection TC {
-                typedef B is A
+                typedef B is TC.A
             }
         """)
         self.processor.import_file(fspec)
@@ -353,12 +353,12 @@ class TestReferences(BaseTestCase):
         self.assertTrue(isinstance(a2.type, ast.UInt32))
         b = self.processor.packages["P2"].typecollections["TC"].typedefs["B"]
         self.assertTrue(isinstance(b.type, ast.Reference))
-        self.assertEqual(b.type.name, "A")
+        self.assertEqual(b.type.name, "TC.A")
         self.assertEqual(b.type.reference, a)
 
     def test_unresolved_reference_in_typedef(self):
         with self.assertRaises(ProcessorException) as context:
-            fspec = self.tmp_fidl ("test.fidl", """
+            fspec = self.tmp_fidl("test.fidl", """
                 package P
                 typeCollection TC {
                     typedef TD is Unknown
@@ -371,7 +371,7 @@ class TestReferences(BaseTestCase):
 
     def test_unresolved_reference_in_struct(self):
         with self.assertRaises(ProcessorException) as context:
-            fspec = self.tmp_fidl ("test.fidl", """
+            fspec = self.tmp_fidl("test.fidl", """
                 package P
                 typeCollection TC {
                     struct S {
@@ -386,7 +386,7 @@ class TestReferences(BaseTestCase):
 
     def test_unresolved_reference_in_array(self):
         with self.assertRaises(ProcessorException) as context:
-            fspec = self.tmp_fidl ("test.fidl", """
+            fspec = self.tmp_fidl("test.fidl", """
                 package P
                 typeCollection TC {
                     array A of Unknown
@@ -399,7 +399,7 @@ class TestReferences(BaseTestCase):
 
     def test_unresolved_reference_in_map(self):
         with self.assertRaises(ProcessorException) as context:
-            fspec = self.tmp_fidl ("test.fidl", """
+            fspec = self.tmp_fidl("test.fidl", """
                 package P
                 typeCollection TC {
                     map M { Unknown to Int32 }
@@ -412,7 +412,7 @@ class TestReferences(BaseTestCase):
 
     def test_unresolved_reference_in_map2(self):
         with self.assertRaises(ProcessorException) as context:
-            fspec = self.tmp_fidl ("test.fidl", """
+            fspec = self.tmp_fidl("test.fidl", """
                 package P
                 typeCollection TC {
                     map M { Int32 to Unknown }
@@ -425,7 +425,7 @@ class TestReferences(BaseTestCase):
 
     def test_unresolved_reference_in_attribute(self):
         with self.assertRaises(ProcessorException) as context:
-            fspec = self.tmp_fidl ("test.fidl", """
+            fspec = self.tmp_fidl("test.fidl", """
                 package P
                 interface I {
                     attribute Unknown A
@@ -438,7 +438,7 @@ class TestReferences(BaseTestCase):
 
     def test_unresolved_reference_in_method(self):
         with self.assertRaises(ProcessorException) as context:
-            fspec = self.tmp_fidl ("test.fidl", """
+            fspec = self.tmp_fidl("test.fidl", """
                 package P
                 interface I {
                     method M { in { Unknown a } }
@@ -451,7 +451,7 @@ class TestReferences(BaseTestCase):
 
     def test_unresolved_reference_in_method2(self):
         with self.assertRaises(ProcessorException) as context:
-            fspec = self.tmp_fidl ("test.fidl", """
+            fspec = self.tmp_fidl("test.fidl", """
                 package P
                 interface I {
                     method M { out { Unknown a } }
@@ -464,7 +464,7 @@ class TestReferences(BaseTestCase):
 
     def test_unresolved_reference_in_method3(self):
         with self.assertRaises(ProcessorException) as context:
-            fspec = self.tmp_fidl ("test.fidl", """
+            fspec = self.tmp_fidl("test.fidl", """
                 package P
                 interface I {
                     method M { error Unknown }
@@ -477,7 +477,7 @@ class TestReferences(BaseTestCase):
 
     def test_unresolved_reference_in_broadcast(self):
         with self.assertRaises(ProcessorException) as context:
-            fspec = self.tmp_fidl ("test.fidl", """
+            fspec = self.tmp_fidl("test.fidl", """
                 package P
                 interface I {
                     broadcast B { out { Unknown a } }
@@ -489,7 +489,7 @@ class TestReferences(BaseTestCase):
                          "Unresolved reference 'Unknown'.")
 
     def test_method_error_reference(self):
-        fspec = self.tmp_fidl ("test.fidl", """
+        fspec = self.tmp_fidl("test.fidl", """
             package P
             interface I {
                 enumeration E { A B C }
@@ -506,7 +506,7 @@ class TestReferences(BaseTestCase):
 
     def test_invalid_method_error_reference(self):
         with self.assertRaises(ProcessorException) as context:
-            fspec = self.tmp_fidl ("test.fidl", """
+            fspec = self.tmp_fidl("test.fidl", """
                 package P
                 interface I {
                     typedef E is String
@@ -519,7 +519,7 @@ class TestReferences(BaseTestCase):
                          "Invalid error reference 'E'.")
 
     def test_enumeration_extension(self):
-        fspec = self.tmp_fidl ("test.fidl", """
+        fspec = self.tmp_fidl("test.fidl", """
             package P
             interface I {
                 enumeration E { A B C }
@@ -534,7 +534,7 @@ class TestReferences(BaseTestCase):
 
     def test_invalid_enumeration_extension(self):
         with self.assertRaises(ProcessorException) as context:
-            fspec = self.tmp_fidl ("test.fidl", """
+            fspec = self.tmp_fidl("test.fidl", """
                 package P
                 interface I {
                     typedef E is String
@@ -547,7 +547,7 @@ class TestReferences(BaseTestCase):
                          "Invalid enumeration reference 'E'.")
 
     def test_struct_extension(self):
-        fspec = self.tmp_fidl ("test.fidl", """
+        fspec = self.tmp_fidl("test.fidl", """
             package P
             interface I {
                 struct S { Int32 a }
@@ -562,7 +562,7 @@ class TestReferences(BaseTestCase):
 
     def test_invalid_struct_extension(self):
         with self.assertRaises(ProcessorException) as context:
-            fspec = self.tmp_fidl ("test.fidl", """
+            fspec = self.tmp_fidl("test.fidl", """
                 package P
                 interface I {
                     typedef S is String
@@ -575,7 +575,7 @@ class TestReferences(BaseTestCase):
                          "Invalid struct reference 'S'.")
 
     def test_interface_extension(self):
-        fspec = self.tmp_fidl ("test.fidl", """
+        fspec = self.tmp_fidl("test.fidl", """
             package P
             interface I { }
             interface I2 extends I { }
@@ -590,11 +590,11 @@ class TestReferences(BaseTestCase):
         self.assertEqual(i3.reference, i)
 
     def test_interface_extension2(self):
-        self.tmp_fidl ("test.fidl", """
+        self.tmp_fidl("test.fidl", """
             package P
             interface I { }
         """)
-        fspec = self.tmp_fidl ("test2.fidl", """
+        fspec = self.tmp_fidl("test2.fidl", """
             package P2
             import model "test.fidl"
             interface I2 extends I { }
@@ -610,7 +610,7 @@ class TestReferences(BaseTestCase):
 
     def test_invalid_interface_extension(self):
         with self.assertRaises(ProcessorException) as context:
-            fspec = self.tmp_fidl ("test.fidl", """
+            fspec = self.tmp_fidl("test.fidl", """
                 package P
                 typeCollection TC { typedef I is Int32 }
                 interface I2 extends I { }
@@ -621,7 +621,7 @@ class TestReferences(BaseTestCase):
                          "Unresolved namespace reference 'I'.")
 
     def test_anonymous_array_references(self):
-        fspec = self.tmp_fidl ("test.fidl", """
+        fspec = self.tmp_fidl("test.fidl", """
             package P
             typeCollection TC {
                 typedef TD is Int32
@@ -766,3 +766,78 @@ class TestReferences(BaseTestCase):
                 os.path.join(self.get_spec("idl3"), "P2.fidl"))
         self.assertEqual(str(context.exception),
                          "Unresolved reference 'T1Enum'.")
+
+    # ths test should raise an exception because MyEnum is ambiguous in P.fidl
+    def test_ambiguous_types(self):
+        with self.assertRaises(ProcessorException) as context:
+            self.tmp_fidl("common.fidl", """
+                        package P
+                        typeCollection T1 {
+                            enumeration MyEnum {
+                                abc
+                            }
+                        }
+
+                        typeCollection T2 {
+                            enumeration MyEnum {
+                                abc
+                            }
+                        }
+                    """)
+
+            fspec = self.tmp_fidl("P.fidl", """
+                        package P
+                        import model "common.fidl"
+
+                        interface I {
+                            version { major 1 minor 0 }
+                            method getData {
+                                out {
+                                      MyEnum outVal
+                                   }
+                            }
+                        }
+                    """)
+            self.processor.import_file(fspec)
+
+        self.assertEqual(str(context.exception),
+                     "Reference 'MyEnum' is ambiguous.")
+
+
+    def test_model_import(self):
+        self.tmp_fidl("common.fidl", """
+                    package P
+                    typeCollection T1 {
+                        enumeration Enum_T1 {
+                            abc
+                        }
+                    }
+
+                    typeCollection T2 {
+                        enumeration Enum_T2 {
+                            abc
+                        }
+                    }
+                """)
+
+        fspec = self.tmp_fidl("P.fidl", """
+                    package P
+                    import model "common.fidl"
+
+                    interface I {
+                        version { major 1 minor 0 }
+                        method getData {
+                            out {
+                                  Enum_T1 out_t1
+                                  Enum_T2 out_t2
+                            }
+                        }
+                    }
+                """)
+        self.processor.import_file(fspec)
+        self.assertEqual(self.processor.packages["P"].name, "P")
+        self.assertEqual(self.processor.packages['P'].interfaces["I"].methods["getData"].
+                         out_args["out_t1"].type.reference.namespace.name, "T1")
+        self.assertEqual(self.processor.packages['P'].interfaces["I"].methods["getData"].
+                         out_args["out_t2"].type.reference.namespace.name, "T2")
+


### PR DESCRIPTION
This is a first draft of import rework. This request replaces the old one. My initial solution has mistakes by design -> forgot to consider circular package dependencies. Now this solution should handle the package import correctly.

The import behavior is changed. Now each namespace has a list of imported namepsace that are visible in the corresponding fidl file. 

The unittest are green. But I think further test are neccessary. This draft should give you an impression of my solution. Any comment is welcome. 

- replace import_string() with tmp_fidl() --> temporary file creation, no further need to import srings wtih simulated file handling.
- fqn solbver uses namespace references instead of package references
- currently transistive import not allowed.